### PR TITLE
Ignore `ca_cert` when `insecure_tls` is set to `true`

### DIFF
--- a/connection_producer.go
+++ b/connection_producer.go
@@ -76,9 +76,9 @@ func (c *redisDBConnectionProducer) Init(ctx context.Context, initConfig map[str
 
 	c.Addr = net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
 
-	if c.TLS {
+	if c.TLS && !c.InsecureTLS {
 		if len(c.CACert) == 0 {
-			return nil, fmt.Errorf("ca_cert cannot be empty")
+			return nil, fmt.Errorf("ca_cert cannot be empty when InsecureTLS is false")
 		}
 	}
 
@@ -114,20 +114,24 @@ func (c *redisDBConnectionProducer) Connection(ctx context.Context) (interface{}
 	var poolConfig radix.PoolConfig
 
 	if c.TLS {
-		rootCAs := x509.NewCertPool()
-		ok := rootCAs.AppendCertsFromPEM([]byte(c.CACert))
-		if !ok {
-			return nil, fmt.Errorf("failed to parse root certificate")
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: c.InsecureTLS,
 		}
+		if !c.InsecureTLS && len(c.CACert) > 0 {
+			rootCAs := x509.NewCertPool()
+			ok := rootCAs.AppendCertsFromPEM([]byte(c.CACert))
+			if !ok {
+				return nil, fmt.Errorf("failed to parse root certificate")
+			}
+			tlsConfig.RootCAs = rootCAs
+		}
+
 		poolConfig = radix.PoolConfig{
 			Dialer: radix.Dialer{
 				AuthUser: c.Username,
 				AuthPass: c.Password,
 				NetDialer: &tls.Dialer{
-					Config: &tls.Config{
-						RootCAs:            rootCAs,
-						InsecureSkipVerify: c.InsecureTLS,
-					},
+					Config: tlsConfig,
 				},
 			},
 		}

--- a/redis_test.go
+++ b/redis_test.go
@@ -131,6 +131,7 @@ func TestDriver(t *testing.T) {
 
 	t.Run("Init", func(t *testing.T) { testRedisDBInitialize_NoTLS(t, host, port) })
 	t.Run("Init", func(t *testing.T) { testRedisDBInitialize_TLS(t, host, port) })
+	t.Run("Init", func(t *testing.T) { testRedisDBInitialize_TLSInsecure(t, host, port) })
 	t.Run("Create/Revoke", func(t *testing.T) { testRedisDBCreateUser(t, host, port) })
 	t.Run("Create/Revoke", func(t *testing.T) { testRedisDBCreateUser_DefaultRule(t, host, port) })
 	t.Run("Create/Revoke", func(t *testing.T) { testRedisDBCreateUser_plusRole(t, host, port) })
@@ -204,6 +205,27 @@ func testRedisDBInitialize_TLS(t *testing.T, host string, port int) {
 		"password":     adminPassword,
 		"tls":          true,
 		"ca_cert":      CACert,
+		"insecure_tls": false,
+	}
+	err = setupRedisDBInitialize(t, connectionDetails)
+	if err != nil {
+		t.Fatalf("Testing TLS Init() failed: error: %s", err)
+	}
+}
+
+func testRedisDBInitialize_TLSInsecure(t *testing.T, host string, port int) {
+	if !redisTls {
+		t.Skip("skipping TLS Init() test in plain text mode")
+	}
+
+	t.Log("Testing TLS Init()")
+
+	connectionDetails := map[string]interface{}{
+		"host":         host,
+		"port":         port,
+		"username":     adminUsername,
+		"password":     adminPassword,
+		"tls":          true,
 		"insecure_tls": true,
 	}
 	err = setupRedisDBInitialize(t, connectionDetails)


### PR DESCRIPTION
# Overview
A high level description of the contribution, including:

I have recently enable TLS for my redis instance and noticed that even when `--insecure` flag is set, you need to explicitly set `--tls` flag in order to be able to interact with the server:
```
$ redis-cli -h redis-wave-tasks.ug.wavemm.net -p 6379  --insecure -a $REDIS_PASSWORD ping                                                                                   
Error: Connection reset by peer
$ redis-cli -h redis.myurl.com -p 6379  --insecure --tls -a $REDIS_PASSWORD ping                                                                                            
PONG
```

When using the `vault-config-operator` and so the `DatabaseSecretEngineConfig` CRD, similarly when setting `spec.databaseSpecificConfig.insecure_tls` to `true`, I still get the same `Error: Connection reset by peer`. So, as before you need to set `spec.databaseSpecificConfig.tls` to `true`.

However, as plugin code expects `ca_cert` to be set when `tls` is enabled, it errors out. So, I was being forced to set a random cA there, just for the same of being able to get redis creds. 

The PR, simply avoids setting the `ca_cert` when `tls` && `insecure_tls` are set to true.

Technically, we could technically assume that when `insecure_tls` is set, no need for `tls` flag as could be inferred, but as the `redis-cli` also expects it, in order to be aligned I kept the same approach.


# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [X] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [X] Backwards compatible




