### PR TITLE
[CHANGELOG] Prepare for v0.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 
 * Automated dependency upgrades (#107)
 
-## Unreleased
 ## v0.8.0
 ### March 16, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.8.1
+### March 19, 2026
+
+* Automated dependency upgrades (#107)
+
 ## Unreleased
 ## v0.8.0
 ### March 16, 2026


### PR DESCRIPTION
Changelog update for version [v0.8.1](https://github.com/hashicorp/vault-plugin-database-redis/releases/tag/v0.8.1).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/23320425602

